### PR TITLE
Remove username from User model

### DIFF
--- a/configuration_default.yaml
+++ b/configuration_default.yaml
@@ -169,7 +169,6 @@ authentication_methods:
         privateKey: ""
 
         attrs:
-          username: 'urn:oid:0.9.2342.19200300.100.1.1'
           realname: 'urn:oid:2.16.840.1.113730.3.1.241'
           email: 'urn:oid:0.9.2342.19200300.100.1.3'
 

--- a/syllabus/admin/templates/admin_base.html
+++ b/syllabus/admin/templates/admin_base.html
@@ -67,7 +67,7 @@
                     <li class="dropdown user user-menu">
                         <!-- Menu Toggle Button -->
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                            <span class="hidden-xs">{{ session["user"]["username"] }}</span>
+                            <span class="hidden-xs">{{ session["user"]["email"] }}</span>
                         </a>
                         <ul class="dropdown-menu">
                             <!-- Menu Footer-->

--- a/syllabus/database.py
+++ b/syllabus/database.py
@@ -162,7 +162,6 @@ def locally_register_new_user(user, activated=False):
     if existing_user is not None:
         exception = UserAlreadyExists("tried to create user {} while user {} already exists".format(user.to_dict,
                                                                                               existing_user.to_dict()))
-        exception.reason = "email"
         raise exception
     db_session.add(user)
     db_session.commit()

--- a/syllabus/inginious_syllabus.py
+++ b/syllabus/inginious_syllabus.py
@@ -483,9 +483,7 @@ def register():
             set_feedback(session, SuccessFeedback(feedback_message), feedback_type="login")
             return seeother("/login")
         except UserAlreadyExists as e:
-            set_feedback(session, ErrorFeedback("Could not register: this user already exists{}.".format(
-                                                (": %s" % e.reason) if e.reason is not None else "")),
-                         feedback_type="login")
+            set_feedback(session, ErrorFeedback("Could not register: this user already exists."), feedback_type="login")
             db_session.rollback()
             return seeother("/register")
 

--- a/syllabus/models/user.py
+++ b/syllabus/models/user.py
@@ -8,17 +8,15 @@ from hashlib import sha512, pbkdf2_hmac, sha256
 
 class User(Base):
     __tablename__ = 'users'
-    username = Column(String(40), primary_key=True, index=True)
-    email = Column(String(120), unique=True, nullable=False)
+    email = Column(String(120), primary_key=True, index=True)
     full_name = Column(String(50))
     hash_password = Column(String(80))
     change_password_url = Column(String(50))
     right = Column(String(30))
     activated = Column(Boolean(), nullable=False, default=False)
 
-    def __init__(self, name, email, hash_password, full_name=None, change_password_url=None, right=None,
+    def __init__(self, email, hash_password, full_name=None, change_password_url=None, right=None,
                  activated=False):
-        self.username = name
         self.email = email
         self.hash_password = hash_password
         self.full_name = full_name
@@ -27,10 +25,11 @@ class User(Base):
         self.activated = activated
 
     def to_dict(self):
-        return {"username": self.username, "email": self.email, "right": self.right}
+        # Username field is deprecated and kept here for retro-compatibility
+        return {"username": self.email, "email": self.email, "right": self.right}
 
     def __repr__(self):
-        return '<User %r>' % (self.username)
+        return '<User %r>' % self.email
 
     @property
     def admin(self):

--- a/syllabus/models/user.py
+++ b/syllabus/models/user.py
@@ -66,7 +66,4 @@ def verify_activation_mac(email: str, secret: str, timestamp: int, mac_to_verify
 
 
 class UserAlreadyExists(Exception):
-    def __init__(self, message):
-        self.message = message
-        self.reason = None
-        super().__init__(self.message)
+    pass

--- a/syllabus/templates/local_register_confirmed_account.html
+++ b/syllabus/templates/local_register_confirmed_account.html
@@ -21,9 +21,7 @@
         {% endif %}
 
       <form class="form-signin" method="post">
-        <h2 class="form-signin-heading">Choose a username and password</h2>
-        <label for="inputUsername" class="sr-only">Username</label>
-        <input type="text" id="inputUsername" class="form-control" placeholder="Username" required autofocus name="username">
+        <h2 class="form-signin-heading">Choose a password</h2>
         <label for="inputPassword" class="sr-only">Password</label>
         <input type="password" minlength="6" id="inputPassword" class="form-control" placeholder="Password" required name="password">
         <label for="repeatPassword" class="sr-only">Confirm password</label>

--- a/syllabus/templates/register.html
+++ b/syllabus/templates/register.html
@@ -23,12 +23,10 @@
         {% if "local" in auth_methods %}
           <form class="form-signin" method="post">
             <h2 class="form-signin-heading">Please register</h2>
-            <label for="inputUsername" class="sr-only">E-mail</label>
+            <label for="inputEmail" class="sr-only">E-mail</label>
             <input type="text" id="inputEmail" class="form-control" placeholder="E-mail" required name="email">
 
             {% if not activation_required %}
-                <label for="inputUsername" class="sr-only">Username</label>
-                <input type="text" id="inputUsername" class="form-control" placeholder="Username" required autofocus name="username">
                 <label for="inputPassword" class="sr-only">Password</label>
                 <input type="password" minlength="6" id="inputPassword" class="form-control" placeholder="Password" required name="password">
                 <label for="repeatPassword" class="sr-only">Confirm password</label>

--- a/syllabus/templates/rst_page.html
+++ b/syllabus/templates/rst_page.html
@@ -164,7 +164,7 @@
                     {% if logged_in["right"] == "admin" %}
                         <li><a href="/admin/users" style="display: block">Admin Panel</a></li>
                     {% endif %}
-                    <li><a href="/logout" style="display: block">Log out ({{ logged_in['username'] }})</a></li>
+                    <li><a href="/logout" style="display: block">Log out ({{ logged_in['email'] }})</a></li>
                 {% else %}
                     <li>
                       <a href="/login">Log in</a>

--- a/syllabus/templates/sphinx_page.html
+++ b/syllabus/templates/sphinx_page.html
@@ -33,7 +33,7 @@
                 {% if logged_in["right"] == "admin" %}
                     <li><a href="/admin/users" style="display: block">Admin Panel</a></li>
                 {% endif %}
-                <li><a href="/logout" style="display: block">Log out ({{ logged_in['username'] }})</a></li>
+                <li><a href="/logout" style="display: block">Log out ({{ logged_in['email'] }})</a></li>
             {% else %}
                 <li>
                   <a href="/login">Log in</a>


### PR DESCRIPTION
This follows and fixes #23. The username is no longer used but makes conflict when one of the (username, email) field is changed.

- Removed the username usage throughout the code
- Added database migration code and refactored version 2->3 update code.
- Kept `username` field set to email in the User dict representation for retrocompatibility/ease migration as the field is used in some syllabus template configurations.
- Removed `UserAlreadyExists.reason` attribute.